### PR TITLE
feat: add new parameter for overlapping prev month

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,20 @@ Specifies which source(s) to collect PRs from:
 docker-compose run --rm kup --source github
 ```
 
+### `--days-before <N>`
+
+Includes PRs merged up to N days before the start of the current month. Useful when the previous month's report was generated a few days before month-end, leaving some PRs uncaptured.
+
+For example, if the current month is February, `--days-before 3` shifts the search window start from February 1 to January 29, so PRs merged on Jan 29–31 are included in the February report.
+
+- Default: `0` (report starts from the 1st of the current month)
+- Only affects the data collection window — the report title and working days remain for the current month
+
+**Example:**
+```bash
+docker-compose run --rm kup --source github --days-before 3
+```
+
 ## Environment Variables
 
 ### Required (Common)

--- a/report.sh
+++ b/report.sh
@@ -2,6 +2,7 @@
 set -o pipefail
 
 START_DATE=$(date +%Y-%m-01T00:00:00.000000+00:00)
+DAYS_BEFORE=0
 
 # parse options
 DEBUG=0
@@ -36,9 +37,23 @@ while [[ "$#" -gt 0 ]]; do
                 *) print_error "Invalid source: $1, values are 'azure', 'github', or 'both'"; exit 1 ;;
             esac
             ;;
+        --days-before)
+            shift
+            if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+                print_error "Invalid --days-before value: '$1', must be a non-negative integer"
+                exit 1
+            fi
+            DAYS_BEFORE="$1"
+            ;;
     esac
     shift
 done
+
+# Shift START_DATE back by DAYS_BEFORE days if specified
+if (( DAYS_BEFORE > 0 )); then
+    START_DATE=$(date -d "$(date +%Y-%m-01) - $DAYS_BEFORE days" +%Y-%m-%dT00:00:00.000000+00:00)
+    print_debug "START_DATE shifted back by $DAYS_BEFORE days to $START_DATE"
+fi
 
 # Default to both sources if none specified
 if [ ${#SOURCES[@]} -eq 0 ]; then


### PR DESCRIPTION
### `--days-before <N>`

Includes PRs merged up to N days before the start of the current month. Useful when the previous month's report was generated a few days before month-end, leaving some PRs uncaptured.

For example, if the current month is February, `--days-before 3` shifts the search window start from February 1 to January 29, so PRs merged on Jan 29–31 are included in the February report.

- Default: `0` (report starts from the 1st of the current month)
- Only affects the data collection window — the report title and working days remain for the current month

**Example:**
```bash
docker-compose run --rm kup --source github --days-before 3