### PR TITLE
fix: use work item owner instead of PR author for GitHub PRs

### DIFF
--- a/lib/github.sh
+++ b/lib/github.sh
@@ -146,11 +146,7 @@ function append_github_pr_line() {
         workitem_cell="{\small $pr_title}"
     fi
 
-    # Get PR author as owner
-    owner_name=$(echo "$pr" | jq -r '.user.login')
-    owner_email=$(echo "$pr" | jq -r '.user.email // ""')
-    
-    # set manager as OWNER in case when we cannot find owner
+    # set manager as OWNER in case when we cannot find owner from the workitem
     if [ -z "$owner_email" ]; then
         owner_email=$manager_email
         owner_name=$manager_display


### PR DESCRIPTION
## Summary
GitHub PR rows in the KUP report always showed the manager as the work item
owner, while Azure DevOps rows showed the correct owner.

## Root cause
In `append_github_pr_line`, after correctly extracting the owner from the linked
Azure DevOps work item (`Custom.Owner`), the code overwrote it with the GitHub
PR author:

    owner_name=$(echo "$pr" | jq -r '.user.login')
    owner_email=$(echo "$pr" | jq -r '.user.email // ""')

GitHub's API rarely exposes `.user.email`, so `owner_email` ended up empty and
the manager fallback kicked in for every PR.

## Fix
Remove the PR-author override so GitHub behaves like Azure DevOps: owner comes
from the linked work item's `Custom.Owner`, with the manager as fallback only
when no owner is set.

## Testing
- Ran `docker-compose run --rm kup --source github --mode debug` on real data.
- Owner column now shows actual work item owners; manager appears only for
  work items with no owner set.