### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,6 +1,7 @@
 name: Release & Build Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Allow the Release & Build Docker Image workflow to be run manually from the Actions tab, so a failed or deleted release run can be re-triggered without pushing a new commit.